### PR TITLE
updating to the most recent SDK

### DIFF
--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -65,9 +65,8 @@
     <Reference Include="LiveCharts.Wpf, Version=0.9.7.0, Culture=neutral, PublicKeyToken=0bc1f845d1ebb8df, processorArchitecture=MSIL">
       <HintPath>packages\LiveCharts.Wpf.0.9.7\lib\net45\LiveCharts.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Playnite.SDK, Version=6.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.4.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/source/packages.config
+++ b/source/packages.config
@@ -4,7 +4,7 @@
   <package id="FuzzySharp" version="2.0.2" targetFramework="net462" />
   <package id="LiveCharts" version="0.9.7" targetFramework="net462" />
   <package id="LiveCharts.Wpf" version="0.9.7" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.4.0" targetFramework="net462" />
   <package id="System.IO.Abstractions" version="2.1.0.227" targetFramework="net462" />
   <package id="YamlDotNet" version="5.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
This just makes the SDK version 6.4.0 instead of 6.2.2. This should get the extension running on Playnite 10